### PR TITLE
feat: Improve a node's ability to ignore a previously seen message

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,34 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Important for GitVersion
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.x'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+
+      - name: Build
+        run: dotnet build --configuration Release /p:Version=${{ steps.gitversion.outputs.semVer }}
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build

--- a/GossNet.Protocol.Tests/ExpiringMessageCacheTests.cs
+++ b/GossNet.Protocol.Tests/ExpiringMessageCacheTests.cs
@@ -1,0 +1,180 @@
+namespace GossNet.Protocol.Tests;
+
+[TestClass]
+public class ExpiringMessageCacheTests
+{
+    [TestMethod]
+    public void TryAdd_NewMessage_ReturnsTrue()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var id = Guid.NewGuid();
+        var message = new TestMessage(id) { Content = "Test" };
+
+        // Act
+        var result = cache.TryAdd(message);
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, cache.Count);
+    }
+
+    [TestMethod]
+    public void TryAdd_DuplicateMessage_ReturnsFalse()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var messageId = Guid.NewGuid();
+        var message1 = new TestMessage(messageId) { Content = "Test 1" };
+        var message2 = new TestMessage(messageId) { Content = "Test 2" };
+
+        // Act
+        var result1 = cache.TryAdd(message1);
+        var result2 = cache.TryAdd(message2);
+
+        // Assert
+        Assert.IsTrue(result1);
+        Assert.IsFalse(result2);
+        Assert.AreEqual(1, cache.Count);
+    }
+
+    [TestMethod]
+    public void Contains_ExistingMessage_ReturnsTrue()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var messageId = Guid.NewGuid();
+        var message = new TestMessage(messageId) { Content = "Test" };
+        cache.TryAdd(message);
+
+        // Act
+        var result = cache.Contains(messageId);
+
+        // Assert
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void Contains_NonExistingMessage_ReturnsFalse()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var result = cache.Contains(messageId);
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void TryGetValue_ExistingMessage_ReturnsMessageAndTrue()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var messageId = Guid.NewGuid();
+        var message = new TestMessage(messageId) { Content = "Test" };
+        cache.TryAdd(message);
+
+        // Act
+        var result = cache.TryGetValue(messageId, out var retrievedMessage);
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.IsNotNull(retrievedMessage);
+        Assert.AreEqual(messageId, retrievedMessage.Id);
+        Assert.AreEqual("Test", retrievedMessage.Content);
+    }
+
+    [TestMethod]
+    public void TryGetValue_NonExistingMessage_ReturnsFalse()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var messageId = Guid.NewGuid();
+
+        // Act
+        var result = cache.TryGetValue(messageId, out var retrievedMessage);
+
+        // Assert
+        Assert.IsFalse(result);
+        Assert.AreEqual(default, retrievedMessage);
+    }
+
+    [TestMethod]
+    public void GetAll_ReturnsAllMessages()
+    {
+        // Arrange
+        var cache = new ExpiringMessageCache<TestMessage>();
+        var message1 = new TestMessage(Guid.NewGuid()) { Content = "Test 1" };
+        var message2 = new TestMessage(Guid.NewGuid()) { Content = "Test 2" };
+        var message3 = new TestMessage(Guid.NewGuid()) { Content = "Test 3" };
+
+        cache.TryAdd(message1);
+        cache.TryAdd(message2);
+        cache.TryAdd(message3);
+
+        // Act
+        var messages = cache.GetAll().ToList();
+
+        // Assert
+        Assert.AreEqual(3, messages.Count);
+        CollectionAssert.Contains(messages, message1);
+        CollectionAssert.Contains(messages, message2);
+        CollectionAssert.Contains(messages, message3);
+    }
+
+    [TestMethod]
+    public async Task Messages_ExpireAfterTimespan()
+    {
+        // Arrange
+        var expiration = TimeSpan.FromMilliseconds(100);
+        var cache = new ExpiringMessageCache<TestMessage>(expiration);
+        var messageId = Guid.NewGuid();
+        var message = new TestMessage(messageId) { Content = "Test" };
+
+        // Act
+        cache.TryAdd(message);
+        Assert.IsTrue(cache.Contains(messageId), "Message should be in cache initially");
+
+        // Wait for expiration
+        await Task.Delay(expiration + TimeSpan.FromMilliseconds(50));
+
+        // Assert
+        Assert.IsFalse(cache.Contains(messageId), "Message should have expired");
+        Assert.AreEqual(0, cache.GetAll().Count(), "GetAll should return empty collection after expiration");
+    }
+
+    private class TestMessage : GossNetMessageBase
+    {
+        public string Content { get; set; } = string.Empty;
+        
+        // Add constructor that accepts an ID
+        public TestMessage(Guid? id = null)
+        {
+            if (id.HasValue)
+            {
+                SetId(id.Value);
+            }
+        }
+        
+        // Add method to set ID using reflection (for testing only)
+        private void SetId(Guid id)
+        {
+            var property = typeof(GossNetMessageBase).GetProperty("Id");
+            property?.SetValue(this, id);
+        }
+
+        public override void Deserialize(string data)
+        {
+            // Not needed for tests
+        }
+
+        public override string Serialize()
+        {
+            // Not needed for tests
+            return Content;
+        }
+    }
+}

--- a/GossNet.Protocol.Tests/GossNetMessageBaseTests.cs
+++ b/GossNet.Protocol.Tests/GossNetMessageBaseTests.cs
@@ -10,6 +10,16 @@ public sealed class GossNetMessageBaseTests
     {
         public string Content { get; set; } = string.Empty;
         
+        // Helper methods for testing to work around property access restrictions
+        public void SetId(Guid id) => 
+            typeof(GossNetMessageBase).GetProperty(nameof(Id))?.SetValue(this, id);
+        
+        public void SetTimestamp(DateTime timestamp) => 
+            typeof(GossNetMessageBase).GetProperty(nameof(Timestamp))?.SetValue(this, timestamp);
+        
+        public void SetNotifiedNodes(IEnumerable<GossNetNodeHostEntry> nodes) => 
+            typeof(GossNetMessageBase).GetProperty(nameof(NotifiedNodes))?.SetValue(this, nodes);
+        
         public override string Serialize()
         {
             return $"{Id}|{Timestamp:o}|{Content}";
@@ -21,11 +31,8 @@ public sealed class GossNetMessageBaseTests
 
             if (parts.Length < 3) return;
             
-            Id = Guid.Parse(parts[0]);
-            
-            // Parse as UTC time and keep it as UTC
-            Timestamp = DateTime.Parse(parts[1], CultureInfo.InvariantCulture).ToUniversalTime();
-            
+            SetId(Guid.Parse(parts[0]));
+            SetTimestamp(DateTime.Parse(parts[1], CultureInfo.InvariantCulture).ToUniversalTime());
             Content = parts[2];
         }
     }
@@ -50,7 +57,7 @@ public sealed class GossNetMessageBaseTests
         var newId = Guid.NewGuid();
         
         // Act
-        message.Id = newId;
+        message.SetId(newId);
         
         // Assert
         Assert.AreEqual(newId, message.Id);
@@ -64,7 +71,7 @@ public sealed class GossNetMessageBaseTests
         var newTimestamp = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         
         // Act
-        message.Timestamp = newTimestamp;
+        message.SetTimestamp(newTimestamp);
         
         // Assert
         Assert.AreEqual(newTimestamp, message.Timestamp);
@@ -82,7 +89,7 @@ public sealed class GossNetMessageBaseTests
         };
         
         // Act
-        message.NotifiedNodes = nodes;
+        message.SetNotifiedNodes(nodes);
         
         // Assert
         Assert.AreEqual(2, message.NotifiedNodes.Count());
@@ -93,12 +100,10 @@ public sealed class GossNetMessageBaseTests
     public void Serialize_WithDefaultValues_ReturnsExpectedString()
     {
         // Arrange
-        var message = new TestMessage
-        {
-            Id = Guid.Parse("12345678-1234-1234-1234-123456789012"),
-            Timestamp = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc),
-            Content = "Test Content"
-        };
+        var message = new TestMessage();
+        message.SetId(Guid.Parse("12345678-1234-1234-1234-123456789012"));
+        message.SetTimestamp(new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc));
+        message.Content = "Test Content";
 
         // Act
         var result = message.Serialize();

--- a/GossNet.Protocol/ExpiringMessageCache.cs
+++ b/GossNet.Protocol/ExpiringMessageCache.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace GossNet.Protocol;
+
+public class ExpiringMessageCache<T> where T : GossNetMessageBase
+{
+    private readonly MemoryCache _cache;
+    private readonly TimeSpan _defaultExpiration;
+    private readonly HashSet<string> _keys = [];
+
+    public ExpiringMessageCache(TimeSpan? defaultExpiration = null)
+    {
+        var options = new MemoryCacheOptions
+        {
+            ExpirationScanFrequency = TimeSpan.FromMinutes(1)
+        };
+        _cache = new MemoryCache(options);
+        _defaultExpiration = defaultExpiration ?? TimeSpan.FromMinutes(5);
+    }
+
+    public bool TryAdd(T message)
+    {
+        var key = message.Id.ToString();
+        
+        if (_cache.TryGetValue(key, out _))
+        {
+            // Message already exists
+            return false;
+        }
+
+        _cache.Set(key, message, _defaultExpiration);
+        _keys.Add(key);
+        
+        return true;
+    }
+
+    public bool Contains(Guid messageId)
+    {
+        return _cache.TryGetValue(messageId.ToString(), out _);
+    }
+
+    public bool TryGetValue(Guid messageId, out T message)
+    {
+        var result = _cache.TryGetValue(messageId.ToString(), out var value);
+        
+        message = result ? (T)value! : default!;
+        
+        return result;
+    }
+
+    public IEnumerable<T> GetAll()
+    {
+        var result = new List<T>();
+        
+        foreach (var key in _keys.ToList())
+        {
+            if (_cache.TryGetValue(key, out var value) && value is T typedValue)
+            {
+                result.Add(typedValue);
+            }
+            else
+            {
+                _keys.Remove(key);
+            }
+        }
+        
+        return result;
+    }
+
+    public int Count => _cache.Count;
+}

--- a/GossNet.Protocol/GossNet.Protocol.csproj
+++ b/GossNet.Protocol/GossNet.Protocol.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
     
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.2" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
     </ItemGroup>
 

--- a/GossNet.Protocol/GossNetConfiguration.cs
+++ b/GossNet.Protocol/GossNetConfiguration.cs
@@ -18,4 +18,6 @@ public class GossNetConfiguration
     public NodeDiscovery NodeDiscovery { get; init; }
     
     public  IEnumerable<GossNetNodeHostEntry> StaticNodes { get; init; } = new List<GossNetNodeHostEntry>();
+    
+    public int MessageTtlSeconds { get; init; } = 600;   // Default 10 minutes
 }

--- a/GossNet.Protocol/GossNetMessageBase.cs
+++ b/GossNet.Protocol/GossNetMessageBase.cs
@@ -1,10 +1,68 @@
+using System.Text.Json;
+
 namespace GossNet.Protocol;
 
-public abstract class GossNetMessageBase
+public class GossNetMessageBase
 {
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
-    public IEnumerable<GossNetNodeHostEntry> NotifiedNodes { get; set; } = new List<GossNetNodeHostEntry>();
-    public abstract string Serialize();
-    public abstract void Deserialize(string data);
+    private Guid _id = Guid.NewGuid();
+    private DateTime _timestamp = DateTime.UtcNow;
+    private List<GossNetNodeHostEntry> _notifiedNodes = [];
+
+    public Guid Id 
+    { 
+        get => _id; 
+        internal set => _id = value; 
+    }
+    
+    public DateTime Timestamp 
+    { 
+        get => _timestamp; 
+        internal set => _timestamp = value; 
+    }
+    
+    public IReadOnlyCollection<GossNetNodeHostEntry> NotifiedNodes 
+    { 
+        get => _notifiedNodes; 
+        internal set => _notifiedNodes = value as List<GossNetNodeHostEntry> ?? value.ToList(); 
+    }
+
+    public virtual string Serialize()
+    {
+        return JsonSerializer.Serialize(this, GetType(), SerializeOptions);
+    }
+
+    public virtual void Deserialize(string data)
+    {
+        var deserializedMsg = JsonSerializer.Deserialize<BaseProperties>(data, DeserializeOptions);
+    
+        if (deserializedMsg == null) 
+            throw new JsonException("Failed to deserialize TestMessage");
+        
+        Id = deserializedMsg.Id;
+        Timestamp = deserializedMsg.Timestamp;
+        NotifiedNodes = deserializedMsg.NotifiedNodes;
+    }
+    
+    public override string ToString()
+    {
+        var notifiedNodes = string.Join(", ", NotifiedNodes);
+        return $"Id: {Id}, Timestamp: {Timestamp}, NotifiedNodes: { notifiedNodes }";
+    }
+    
+    private static readonly JsonSerializerOptions SerializeOptions = new()
+    {
+        WriteIndented = true
+    };
+    
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+    
+    private sealed class BaseProperties
+    {
+        public Guid Id { get; set; }
+        public DateTime Timestamp { get; set; }
+        public List<GossNetNodeHostEntry> NotifiedNodes { get; set; } = [];
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # GossNet.Protocol
 
+[![NuGet](https://img.shields.io/nuget/v/GossNet.Protocol.svg)](https://www.nuget.org/packages/GossNet.Protocol)
+
 GossNet (Gossip Network) is a lightweight C# library implementing the [gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) pattern for distributed systems. This library enables efficient message propagation across a network of nodes without the need for centralized coordination.
+
+GossNet.Protocol uses UDP for message communication, allowing for fast and lightweight message passing. It is designed to be simple to use and integrate into existing applications, providing a scalable and resilient communication mechanism for distributed systems. By default, GossNet.Protocol uses UDP port 5055 but this is configurable.
 
 ## What is GossNet?
 
@@ -50,10 +54,7 @@ public class ChatMessage : GossNetMessageBase
             Username = message.Username;
             Content = message.Content;
             
-            // Copy base properties
-            Id = message.Id;
-            Timestamp = message.Timestamp;
-            NotifiedNodes = message.NotifiedNodes;
+            base.Deserialize(data);
         }
     }
 }
@@ -148,6 +149,17 @@ This epidemic spreading ensures the message reaches all nodes in the network eff
 - Automatic handling of duplicate messages
 - Custom message types through generic implementation
 - Simple subscription model for message handling
+
+## Service Discovery
+
+| Method      | Description                     | Status  |
+|-------------|---------------------------------|---------|
+| DNS         | Discover nodes using DNS        | Done    |
+| Consul      | Discover nodes using Consul     | Planned |
+| Kubernetes  | Discover nodes using Kubernetes | Planned |
+| Docker      | Discover nodes using Docker     | Planned |
+| Static List | Manually configure node list    | Done    |
+
 
 ## License
 


### PR DESCRIPTION
This change includes the following:

- A node maintains a cache of previously seen messages it can be sure to ignore. This cache will expire messages out of its collection based on setting the MessageTtlSeconds configuration value. The default value is 10 minutes.
- Protected the base properties of GossNetMessageBase from being changed and also changed this class to a concrete implementation because of serialization requirements.
- Updated impacted unit tests.
- Included a GitHub workflow component to require a successful build and unit tests before a merge is allowed.