### PR TITLE
chore: Rename channel message class

### DIFF
--- a/GossNet.Protocol.Tests/GossNetNodeTests.cs
+++ b/GossNet.Protocol.Tests/GossNetNodeTests.cs
@@ -50,7 +50,7 @@ public class GossNetNodeTests
         // Set up background task to read from channel
         var cts = new CancellationTokenSource();
 
-        GossNetMessageReceivedEventArgs<TestMessage>? result = null;
+        GossNetChannelMessage<TestMessage>? result = null;
         
         var readTask = Task.Run(async () =>
         {

--- a/GossNet.Protocol/GossNetChannelMessage.cs
+++ b/GossNet.Protocol/GossNetChannelMessage.cs
@@ -1,0 +1,6 @@
+namespace GossNet.Protocol;
+
+public class GossNetChannelMessage<T> where T : GossNetMessageBase
+{
+    public required T Message { get; init; }
+}

--- a/GossNet.Protocol/GossNetMessageReceivedEventArgs.cs
+++ b/GossNet.Protocol/GossNetMessageReceivedEventArgs.cs
@@ -1,6 +1,0 @@
-namespace GossNet.Protocol;
-
-public class GossNetMessageReceivedEventArgs<T> : EventArgs where T : GossNetMessageBase
-{
-    public required T Message { get; init; }
-}

--- a/GossNet.Protocol/GossNetNode.cs
+++ b/GossNet.Protocol/GossNetNode.cs
@@ -12,11 +12,10 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
     private CancellationTokenSource? _cancellationTokenSource;
     private Task? _processingTask;
     private readonly ExpiringMessageCache<T> _processedMessages;
-    
-    // Replace EventHandler with Channel
+    private readonly string _nodePrefix;
     private readonly Channel<GossNetChannelMessage<T>> _messageChannel;
     private readonly List<ChannelReader<GossNetChannelMessage<T>>> _subscribers = new();
-    
+
     private readonly SemaphoreSlim _channelSubscribersSemaphoreSlim = new(1, 1);
     private readonly SemaphoreSlim _udpClientReceiveSemaphoreSlim = new(1, 1);
     private readonly SemaphoreSlim _udpClientSendSemaphoreSlim = new(1, 1);
@@ -27,25 +26,26 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
         _udpClient = udpClient ?? new UdpClientAdapter(configuration.Port);
         _udpClient.EnableBroadcast = true;
         _logger = logger ?? NullLoggerFactory.Instance.CreateLogger<GossNetNode<T>>();
+        _nodePrefix = $"[{_configuration.Hostname}:{_configuration.Port}] ";
 
         _processedMessages = new ExpiringMessageCache<T>(
             TimeSpan.FromSeconds(configuration.MessageTtlSeconds));
-        
+
         _messageChannel = Channel.CreateUnbounded<GossNetChannelMessage<T>>(
             new UnboundedChannelOptions { SingleReader = false, SingleWriter = true });
 
-        _logger.LogDebug("GossNetNode initialized on {Hostname}:{Port}", configuration.Hostname, configuration.Port);
+        _logger.LogDebug("{Prefix}GossNetNode initialized", _nodePrefix);
     }
 
     public async Task<ChannelReader<GossNetChannelMessage<T>>> SubscribeAsync()
     {
         await _channelSubscribersSemaphoreSlim.WaitAsync();
-        
+
         try
         {
             var reader = _messageChannel.Reader;
             _subscribers.Add(reader);
-            _logger.LogDebug("Channel subscriber added");
+            _logger.LogDebug("{Prefix}Channel subscriber added", _nodePrefix);
             return reader;
         }
         finally
@@ -57,12 +57,12 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
     public async Task UnsubscribeAsync(ChannelReader<GossNetChannelMessage<T>> reader)
     {
         await _channelSubscribersSemaphoreSlim.WaitAsync();
-        
+
         try
         {
             if (_subscribers.Remove(reader))
             {
-                _logger.LogDebug("Channel subscriber removed");
+                _logger.LogDebug("{Prefix}Channel subscriber removed", _nodePrefix);
             }
         }
         finally
@@ -73,13 +73,13 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
 
     public async Task<int> SendAsync(T message)
     {
-        _logger.LogDebug("Sending message: {Data}", message.Serialize());
+        _logger.LogDebug("{Prefix}Sending message: {Data}", _nodePrefix, message.Serialize());
 
         MarkSelfAsNotified(message);
         _processedMessages.TryAdd(message);
 
         var result = await SocializeMessageAsync(message);
-        _logger.LogDebug("Message sent to {Count} neighbors: {Neighbors}", result, string.Join(", ", message.NotifiedNodes));
+        _logger.LogDebug("{Prefix}Message sent to {Count} neighbors: {Neighbors}", _nodePrefix, result, string.Join(", ", message.NotifiedNodes));
 
         return result;
     }
@@ -94,7 +94,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
         {
             var result = await _udpClient.ReceiveAsync();
             var data = Encoding.UTF8.GetString(result.Buffer);
-            _logger.LogTrace("Received message from {EndPoint}: {Data}", result.RemoteEndPoint, data);
+            _logger.LogTrace("{Prefix}Received message from {EndPoint}: {Data}", _nodePrefix, result.RemoteEndPoint, data);
 
             var message = new T();
             message.Deserialize(data);
@@ -102,7 +102,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error receiving message: {Message}", ex.Message);
+            _logger.LogError(ex, "{Prefix}Error receiving message: {Message}", _nodePrefix, ex.Message);
             throw;
         }
         finally
@@ -115,14 +115,14 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
 
     public void Start()
     {
-        _logger.LogInformation("Starting GossNetNode: {Hostname}:{Port}", _configuration.Hostname, _configuration.Port);
+        _logger.LogInformation("{Prefix}Starting GossNetNode", _nodePrefix);
 
         _cancellationTokenSource = new CancellationTokenSource();
         var token = _cancellationTokenSource.Token;
 
         _processingTask = Task.Run(async () =>
         {
-            _logger.LogDebug("Message processing loop started");
+            _logger.LogDebug("{Prefix}Message processing loop started", _nodePrefix);
 
             while (!token.IsCancellationRequested)
             {
@@ -133,22 +133,22 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
                 }
                 catch (OperationCanceledException oce)
                 {
-                    _logger.LogDebug(oce, "Message processing loop was canceled");
+                    _logger.LogDebug(oce, "{Prefix}Message processing loop was canceled", _nodePrefix);
                     break;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error in message processing loop: {Message}", ex.Message);
+                    _logger.LogError(ex, "{Prefix}Error in message processing loop: {Message}", _nodePrefix, ex.Message);
                 }
             }
 
-            _logger.LogDebug("Message processing loop ended");
+            _logger.LogDebug("{Prefix}Message processing loop ended", _nodePrefix);
         }, token);
     }
 
     public async Task StopAsync()
     {
-        _logger.LogInformation("Stopping GossNetNode on {Hostname}:{Port}", _configuration.Hostname, _configuration.Port);
+        _logger.LogInformation("{Prefix}Stopping GossNetNode", _nodePrefix);
 
         if (_cancellationTokenSource != null)
         {
@@ -162,44 +162,43 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
                 }
                 catch (OperationCanceledException oce)
                 {
-                    _logger.LogDebug(oce, "Processing task was canceled");
+                    _logger.LogDebug(oce, "{Prefix}Processing task was canceled", _nodePrefix);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error waiting for processing task to complete");
+                    _logger.LogError(ex, "{Prefix}Error waiting for processing task to complete", _nodePrefix);
                 }
             }
 
             _cancellationTokenSource.Dispose();
             _cancellationTokenSource = null;
             _processingTask = null;
-            
+
             // Complete the channel when stopping
             _messageChannel.Writer.Complete();
 
-            _logger.LogDebug("GossNetNode stopped");
+            _logger.LogDebug("{Prefix}GossNetNode stopped", _nodePrefix);
         }
     }
 
     private async Task<int> ProcessMessageAsync(T message)
     {
-        _logger.LogDebug("Processing received message: {Data}", message.Serialize());
+        _logger.LogDebug("{Prefix}Processing received message: {Data}", _nodePrefix, message.Serialize());
 
         if (!_processedMessages.TryAdd(message))
         {
-            _logger.LogDebug("Ignoring previously processed message id: {Id}", message.Id);
+            _logger.LogDebug("{Prefix}Ignoring previously processed message id: {Id}", _nodePrefix, message.Id);
             return 0;
         }
 
         MarkSelfAsNotified(message);
-
-        // Write to channel instead of invoking event
+        
         var args = new GossNetChannelMessage<T> { Message = message };
         await WriteToChannelAsync(args);
 
         var result = await SocializeMessageAsync(message);
 
-        _logger.LogDebug("Message processed and forwarded to {Count} nodes", result);
+        _logger.LogDebug("{Prefix}Message processed and forwarded to {Count} nodes", _nodePrefix, result);
 
         return result;
     }
@@ -208,13 +207,13 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
     {
         try
         {
-            _logger.LogTrace("Writing message to channel");
+            _logger.LogTrace("{Prefix}Writing message to channel", _nodePrefix);
             await _messageChannel.Writer.WriteAsync(args);
-            _logger.LogTrace("Message written to channel successfully");
+            _logger.LogTrace("{Prefix}Message written to channel successfully", _nodePrefix);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error writing to message channel");
+            _logger.LogError(ex, "{Prefix}Error writing to message channel", _nodePrefix);
             throw;
         }
     }
@@ -228,7 +227,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
                 Port = _configuration.Port
             }).ToArray();
 
-            _logger.LogTrace("Marked self ({Host}:{Port}) as notified for message id: {Id}", _configuration.Hostname, _configuration.Port, message.Id);
+            _logger.LogTrace("{Prefix}Marked self as notified for message id: {Id}", _nodePrefix, message.Id);
         }
     }
 
@@ -238,7 +237,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
 
         var neighbors = GossNetDiscovery.GetNeighbours(_configuration).ToArray();
         var neighborsString = string.Join(", ", neighbors.Select(n => n.ToString()));
-        _logger.LogDebug("Found {Count} neighbors: {Neighbors}", neighbors.Length, neighborsString);
+        _logger.LogDebug("{Prefix}Found {Count} neighbors: {Neighbors}", _nodePrefix, neighbors.Length, neighborsString);
 
         var sentCount = 0;
 
@@ -246,7 +245,8 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
         {
             if (message.NotifiedNodes.Any(n => n.Hostname == neighbour.Hostname && n.Port == neighbour.Port))
             {
-                _logger.LogTrace("Skipping already notified neighbor {Host}:{Port} for message id: {Id}", neighbour.Hostname, neighbour.Port, message.Id);
+                _logger.LogTrace("{Prefix}Skipping already notified neighbor {Host}:{Port} for message id: {Id}", 
+                    _nodePrefix, neighbour.Hostname, neighbour.Port, message.Id);
                 continue;
             }
 
@@ -257,18 +257,19 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
 
             try
             {
-                _logger.LogTrace("Sending message id: {Id} to {Host}:{Port}", message.Id, hostname, port);
+                _logger.LogTrace("{Prefix}Sending message id: {Id} to {Host}:{Port}", _nodePrefix, message.Id, hostname, port);
                 var result = await _udpClient.SendAsync(data, data.Length, hostname, port);
 
                 if (result > 0)
                 {
                     sentCount++;
-                    _logger.LogTrace("Successfully sent message id: {Id} as {Bytes} bytes to {Host}:{Port}", message.Id, result, hostname, port);
+                    _logger.LogTrace("{Prefix}Successfully sent message id: {Id} as {Bytes} bytes to {Host}:{Port}", 
+                        _nodePrefix, message.Id, result, hostname, port);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error sending message id: {Id} to {Host}:{Port}", message.Id, hostname, port);
+                _logger.LogError(ex, "{Prefix}Error sending message id: {Id} to {Host}:{Port}", _nodePrefix, message.Id, hostname, port);
             }
             finally
             {
@@ -289,7 +290,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
     {
         if (!disposing) return;
 
-        _logger.LogInformation("Disposing GossNetNode");
+        _logger.LogInformation("{Prefix}Disposing GossNetNode", _nodePrefix);
 
         try
         {
@@ -301,7 +302,7 @@ public class GossNetNode<T> : IGossNetNode<T> where T : GossNetMessageBase, new(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error during GossNetNode disposal");
+            _logger.LogError(ex, "{Prefix}Error during GossNetNode disposal", _nodePrefix);
         }
     }
 }

--- a/GossNet.Protocol/IGossNetNode.cs
+++ b/GossNet.Protocol/IGossNetNode.cs
@@ -7,13 +7,13 @@ public interface IGossNetNode<T> : IDisposable where T : GossNetMessageBase, new
     /// <summary>
     /// Subscribes to incoming GossNet messages.
     /// </summary>
-    Task<ChannelReader<GossNetMessageReceivedEventArgs<T>>> SubscribeAsync();
+    Task<ChannelReader<GossNetChannelMessage<T>>> SubscribeAsync();
     
     /// <summary>
     /// Unsubscribes from incoming GossNet messages.
     /// </summary>
     /// <param name="reader">The channel reader.</param>
-    Task UnsubscribeAsync(ChannelReader<GossNetMessageReceivedEventArgs<T>> reader);
+    Task UnsubscribeAsync(ChannelReader<GossNetChannelMessage<T>> reader);
     
     /// <summary>
     /// Sends a message to other nodes in the network.

--- a/README.md
+++ b/README.md
@@ -148,9 +148,6 @@ _ = Task.Run(async () =>
     }
 });
 
-// Give some time for nodes to start up and listen for messages
-await Task.Delay(1000);
-
 // Send a message from node 1
 var message = new ChatMessage
 {

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ using GossNet;
 using GossNet.Protocol;
 using Microsoft.Extensions.Logging;
 using Serilog;
-using Serilog.Events;
 
 // Create logger
 var serilogLogger = new LoggerConfiguration()
@@ -81,30 +80,39 @@ var serilogLogger = new LoggerConfiguration()
 var loggerFactory = new LoggerFactory().AddSerilog(serilogLogger);
 
 // Create typed logger for GossNetNode<TestMessage>
-var logger = loggerFactory.CreateLogger<GossNetNode<TestMessage>>();
+var logger = loggerFactory.CreateLogger<GossNetNode<ChatMessage>>();
 
 // Create and start nodes
-var node1 = new GossNetNode<TestMessage>(new GossNetConfiguration
+var node1 = new GossNetNode<ChatMessage>(new GossNetConfiguration
 {
     Hostname = "localhost",
     NodeDiscovery = NodeDiscovery.StaticList,
-    StaticNodes = new List<GossNetNodeHostEntry> { new() { Hostname = "localhost", Port = 9056 } }
+    StaticNodes = new List<GossNetNodeHostEntry> 
+    { 
+        new() { Hostname = "localhost", Port = 9056 }
+    }
 }, logger);
 
-var node2 = new GossNetNode<TestMessage>(new GossNetConfiguration
+var node2 = new GossNetNode<ChatMessage>(new GossNetConfiguration
 {
     Hostname = "localhost",
     Port = 9056,
     NodeDiscovery = NodeDiscovery.StaticList,
-    StaticNodes = new List<GossNetNodeHostEntry> { new() { Hostname = "localhost", Port = 9057 } }
+    StaticNodes = new List<GossNetNodeHostEntry> 
+    { 
+        new() { Hostname = "localhost", Port = 9057 } 
+    }
 }, logger);
 
-var node3 = new GossNetNode<TestMessage>(new GossNetConfiguration
+var node3 = new GossNetNode<ChatMessage>(new GossNetConfiguration
 {
     Hostname = "localhost",
     Port = 9057,
     NodeDiscovery = NodeDiscovery.StaticList,
-    StaticNodes = new List<GossNetNodeHostEntry> { new() { Hostname = "localhost", Port = 9055 } }
+    StaticNodes = new List<GossNetNodeHostEntry> 
+    { 
+        new() { Hostname = "localhost", Port = 9055 }
+    }
 }, logger);
 
 // Start all nodes first
@@ -118,7 +126,7 @@ _ = Task.Run(async () =>
     var reader1 = await node1.SubscribeAsync();
     await foreach (var messageItem in reader1.ReadAllAsync())
     {
-        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 1] {messageItem.Message.Content}");
+        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 1] {messageItem.Message.Username} : {messageItem.Message.Content}");
     }
 });
 
@@ -127,7 +135,7 @@ _ = Task.Run(async () =>
     var reader2 = await node2.SubscribeAsync();
     await foreach (var messageItem in reader2.ReadAllAsync())
     {
-        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 2] {messageItem.Message.Content}");
+        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 2] {messageItem.Message.Username} : {messageItem.Message.Content}");
     }
 });
 
@@ -136,7 +144,7 @@ _ = Task.Run(async () =>
     var reader3 = await node3.SubscribeAsync();
     await foreach (var messageItem in reader3.ReadAllAsync())
     {
-        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 3] {messageItem.Message.Content}");
+        Console.WriteLine($"[{messageItem.Message.Timestamp} on Node 3] {messageItem.Message.Username} : {messageItem.Message.Content}");
     }
 });
 
@@ -144,8 +152,9 @@ _ = Task.Run(async () =>
 await Task.Delay(1000);
 
 // Send a message from node 1
-var message = new TestMessage
+var message = new ChatMessage
 {
+    Username = "Alice",
     Content = "Hello, world!"
 };
 
@@ -159,11 +168,11 @@ Console.ReadKey();
 When you run this code, you should see the message "Hello, world!" propagated from node 1 to nodes 2 and 3, with each node printing the message to the console.
 
 ```text
-[16:31:09 INF] Starting GossNetNode: localhost:9055
-[16:31:09 INF] Starting GossNetNode: localhost:9056
-[16:31:09 INF] Starting GossNetNode: localhost:9057
-[3/9/2025 8:31:10 PM on Node 2] Hello, world!
-[3/9/2025 8:31:10 PM on Node 3] Hello, world!
+[20:40:15 INF] Starting GossNetNode: localhost:9055
+[20:40:15 INF] Starting GossNetNode: localhost:9056
+[20:40:15 INF] Starting GossNetNode: localhost:9057
+[3/10/2025 12:40:16 AM on Node 2] Alice : Hello, world!
+[3/10/2025 12:40:16 AM on Node 3] Alice : Hello, world!
 Press any key to exit...
 ```
 


### PR DESCRIPTION
This change renames the channel message class to GossNetChannelMessage and also sets a standard log prefix helpful for situations where running multiple nodes in the same application.